### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A Model Context Protocol (MCP) server for Google Calendar integration in Cluade Desktop with auto authentication support. This server enables AI assistants to manage Google Calendar events through natural language interactions.
 
+[![smithery badge](https://smithery.ai/badge/@gongrzhe/server-calendar-autoauth-mcp)](https://smithery.ai/server/@gongrzhe/server-calendar-autoauth-mcp)
 [![npm version](https://badge.fury.io/js/%40gongrzhe%2Fserver-calendar-autoauth-mcp.svg)](https://www.npmjs.com/package/@gongrzhe/server-calendar-autoauth-mcp)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
@@ -18,6 +19,14 @@ A Model Context Protocol (MCP) server for Google Calendar integration in Cluade 
 - Global credential storage for convenience
 
 ## Installation & Authentication
+
+### Installing via Smithery
+
+To install Calendar AutoAuth Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@gongrzhe/server-calendar-autoauth-mcp):
+
+```bash
+npx -y @smithery/cli install @gongrzhe/server-calendar-autoauth-mcp --client claude
+```
 
 1. Create a Google Cloud Project and obtain credentials:
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Calendar AutoAuth Server for Claude Desktop using Smithery CLI. This addition will aid users in simplifying the installation process for the MCP.
2. Adds a badge to display the number of installations from Smithery: https://smithery.ai/server/@gongrzhe/server-calendar-autoauth-mcp

Let me know if any tweaks have to be made!