### PR TITLE
Deployment: Smithery config

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,23 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - calendarOauthPath
+      - calendarCredentialsPath
+    properties:
+      calendarOauthPath:
+        type: string
+        default: ~/.calendar-mcp/gcp-oauth.keys.json
+        description: Path to the Google OAuth credentials file.
+      calendarCredentialsPath:
+        type: string
+        default: ~/.calendar-mcp/credentials.json
+        description: Path where the OAuth tokens will be stored.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['build/index.js'], env: { CALENDAR_OAUTH_PATH: config.calendarOauthPath, CALENDAR_CREDENTIALS_PATH: config.calendarCredentialsPath } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@gongrzhe/server-calendar-autoauth-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂